### PR TITLE
Updates / tweaks (see desc)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,66 +1,62 @@
 FROM debian:stable-20201117-slim AS common
 
-ENV DEBIAN_FRONTEND=noninteractive
+CMD ["/bin/bash"]
 
 ARG REPOSITORY_URL=https://github.com/innovaker/zmk-docker
 LABEL org.opencontainers.image.source ${REPOSITORY_URL}
 
-ARG ZEPHYR_VERSION
-ENV ZEPHYR_VERSION=${ZEPHYR_VERSION}
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ZEPHYR_VERSION=2.4.0
+
 RUN \
   apt-get -y update \
   && apt-get -y install --no-install-recommends \
-  ccache \
-  device-tree-compiler \
-  file \
-  gcc \
-  gcc-multilib \
-  git \
-  gperf \
-  make \
-  ninja-build \
-  python \
-  python3-pip \
-  python3-setuptools \
-  python3-wheel \
+      ccache \
+      device-tree-compiler \
+      file \
+      gcc \
+      gcc-multilib \
+      git \
+      gperf \
+      make \
+      ninja-build \
+      python3 \
+      python3-pip \
+      python3-setuptools \
+      python3-wheel \
   && echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list \
   && apt-get -y update \
-  && apt-get -y -t buster-backports install --no-install-recommends \
-  cmake \
-  && pip3 install \
-  -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-base.txt \
+  && apt-get -y -t buster-backports install --no-install-recommends cmake \
+  && pip3 install -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-base.txt \
   && apt-get remove -y \
-  python3-pip \
-  python3-setuptools \
-  python3-wheel \
+      python3-pip \
+      python3-setuptools \
+      python3-wheel \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* \
-  && cmake --version
-
-CMD ["/bin/bash"]
+  && rm -rf /var/lib/apt/lists/*
 
 #------------------------------------------------------------------------------
 
 FROM common AS build
 
-ARG ZEPHYR_TOOLCHAIN_PLATFORM
-ARG ZEPHYR_TOOLCHAIN_VERSION
+ARG ZEPHYR_TOOLCHAIN_PLATFORM=arm
+ARG ZEPHYR_TOOLCHAIN_VERSION=0.11.4
 ARG ZEPHYR_TOOLCHAIN_SETUP_FILENAME=zephyr-toolchain-${ZEPHYR_TOOLCHAIN_PLATFORM}-${ZEPHYR_TOOLCHAIN_VERSION}-setup.run
 ENV ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-${ZEPHYR_TOOLCHAIN_PLATFORM}-${ZEPHYR_TOOLCHAIN_VERSION}
 ENV ZEPHYR_TOOLCHAIN_VERSION=${ZEPHYR_TOOLCHAIN_VERSION}
 RUN \
   apt-get -y update \
   && apt-get -y install --no-install-recommends \
-  bzip2 \
-  wget \
-  xz-utils \
+      bzip2 \
+      wget \
+      xz-utils \
   && wget -q "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_TOOLCHAIN_VERSION}/${ZEPHYR_TOOLCHAIN_SETUP_FILENAME}" \
   && sh ${ZEPHYR_TOOLCHAIN_SETUP_FILENAME} --quiet -- -d ${ZEPHYR_SDK_INSTALL_DIR} \
   && rm ${ZEPHYR_TOOLCHAIN_SETUP_FILENAME} \
-  && apt-get remove -y \
-  bzip2 \
-  wget \
-  xz-utils \
+  && apt-get remove -y --purge \
+      bzip2 \
+      wget \
+      xz-utils \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -68,35 +64,33 @@ RUN \
 
 FROM build AS dev
 
+ENV DEBIAN_FRONTEND=
+
 RUN \
   apt-get -y update \
   && apt-get -y install --no-install-recommends \
-  clang \
-  curl \
+      curl \
   && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
   && apt-get -y update \
   && apt-get -y install --no-install-recommends \
-  dfu-util \
-  g++-multilib \
-  gpg \
-  gpg-agent \
-  libsdl2-dev \
-  nano \
-  nodejs \
-  python \
-  python3-dev \
-  python3-pip \
-  python3-setuptools \
-  python3-tk \
-  python3-wheel \
-  ssh \
-  wget \
-  xz-utils \
+      clang \
+      dfu-util \
+      g++-multilib \
+      gpg \
+      gpg-agent \
+      libsdl2-dev \
+      nano \
+      nodejs \
+      python3-dev \
+      python3-pip \
+      python3-setuptools \
+      python3-tk \
+      python3-wheel \
+      ssh \
+      wget \
+      xz-utils \
   && pip3 install \
-  -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-build-test.txt \
-  -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-run-test.txt \
+      -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-build-test.txt \
+      -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-run-test.txt \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* \
-  && node --version
-
-ENV DEBIAN_FRONTEND=
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Changes

- Moved CMD up higher to improve caching
- Added default to ENV vars so builds can be run locally without having to resort to finding the github actions matrix for values (this is open ended to keep)
- Removed calls to cmake and node for finding version ; this is unnecessary
- Added some additional spaces so multi-line commands (apt install / pip install) are more obvious and to improve readability
- Move some ENV vars up in the build order to help with caching

## Suggestions

- Given the github action is set to run weekly it is probably good to change to ```debian-slim:stable``` instead of ```debian-[date]-slim:stable``` to get the most recent base container with appropriate updates and fixes (esp security fixes) that come through
- Consider adding ```apt-get upgrade -y``` at the start of the docker file / first step to ensure all packages are up to date for security/bug fixes

## Considerations for others reviewing

- Docker can stop building a container at a specific stage (eg ```$ docker build --target builder -t alexellis2/href-counter:latest .```) so multiple docker files are not necessary for this setup / situation